### PR TITLE
refactor: Allow organization name to be accepted when creating core user

### DIFF
--- a/buildly/management/commands/loadinitialdata.py
+++ b/buildly/management/commands/loadinitialdata.py
@@ -28,17 +28,17 @@ class Command(BaseCommand):
         self._su_group = None
         self._default_org = None
 
-    def _create_oauth_application(self):	
-        if settings.OAUTH_CLIENT_ID and settings.OAUTH_CLIENT_SECRET:	
-            app, created = Application.objects.update_or_create(	
-                client_id=settings.OAUTH_CLIENT_ID,	
-                client_secret=settings.OAUTH_CLIENT_SECRET,	
-                defaults={	
-                    'name': 'buildly oauth2',	
-                    'client_type': Application.CLIENT_PUBLIC,	
-                    'authorization_grant_type': Application.GRANT_PASSWORD,	
-                }	
-            )	
+    def _create_oauth_application(self):
+        if settings.OAUTH_CLIENT_ID and settings.OAUTH_CLIENT_SECRET:
+            app, created = Application.objects.update_or_create(
+                client_id=settings.OAUTH_CLIENT_ID,
+                client_secret=settings.OAUTH_CLIENT_SECRET,
+                defaults={
+                    'name': 'buildly oauth2',
+                    'client_type': Application.CLIENT_PUBLIC,
+                    'authorization_grant_type': Application.GRANT_PASSWORD,
+                }
+            )
             self._application = app
 
     def _create_default_organization(self):

--- a/buildly/management/commands/loadinitialdata.py
+++ b/buildly/management/commands/loadinitialdata.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
+from oauth2_provider.models import Application
 from core.models import ROLE_VIEW_ONLY, ROLE_ORGANIZATION_ADMIN, ROLE_WORKFLOW_ADMIN, ROLE_WORKFLOW_TEAM, \
     Organization, CoreUser, CoreGroup
 
@@ -26,6 +27,19 @@ class Command(BaseCommand):
         self._user = None
         self._su_group = None
         self._default_org = None
+
+    def _create_oauth_application(self):	
+        if settings.OAUTH_CLIENT_ID and settings.OAUTH_CLIENT_SECRET:	
+            app, created = Application.objects.update_or_create(	
+                client_id=settings.OAUTH_CLIENT_ID,	
+                client_secret=settings.OAUTH_CLIENT_SECRET,	
+                defaults={	
+                    'name': 'buildly oauth2',	
+                    'client_type': Application.CLIENT_PUBLIC,	
+                    'authorization_grant_type': Application.GRANT_PASSWORD,	
+                }	
+            )	
+            self._application = app
 
     def _create_default_organization(self):
         if settings.DEFAULT_ORG:
@@ -74,4 +88,5 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self._create_groups()
         self._create_default_organization()
+        self._create_oauth_application()
         self._create_user()

--- a/buildly/tests/test_loadinitialdata.py
+++ b/buildly/tests/test_loadinitialdata.py
@@ -29,7 +29,7 @@ class LoadInitialDataTest(TransactionTestCase):
         logging.disable(logging.NOTSET)
 
     @override_settings(DEBUG=True)
-    @override_settings(OAUTH_CLIENT_ID='123')	
+    @override_settings(OAUTH_CLIENT_ID='123')
     @override_settings(OAUTH_CLIENT_SECRET='456')
     def test_full_initial_data(self):
         args = []
@@ -39,12 +39,12 @@ class LoadInitialDataTest(TransactionTestCase):
         assert CoreGroup.objects.filter(name='Global Admin', is_global=True, permissions=15).count() == 1
         assert Organization.objects.filter(name=settings.DEFAULT_ORG).count() == 1
         assert CoreUser.objects.filter(is_superuser=True).count() == 1
-        assert Application.objects.filter(client_id=settings.OAUTH_CLIENT_ID,	
+        assert Application.objects.filter(client_id=settings.OAUTH_CLIENT_ID,
                                           client_secret=settings.OAUTH_CLIENT_SECRET).count() == 1
 
     @override_settings(DEBUG=True)
     @override_settings(DEFAULT_ORG='')
-    @override_settings(OAUTH_CLIENT_ID='123')	
+    @override_settings(OAUTH_CLIENT_ID='123')
     @override_settings(OAUTH_CLIENT_SECRET='456')
     def test_without_default_organization(self):
         args = []
@@ -54,24 +54,24 @@ class LoadInitialDataTest(TransactionTestCase):
         assert CoreGroup.objects.filter(name='Global Admin', is_global=True, permissions=15).count() == 1
         assert Organization.objects.all().count() == 0
         assert CoreUser.objects.filter(is_superuser=True).count() == 1
-        assert Application.objects.filter(client_id=settings.OAUTH_CLIENT_ID,	
+        assert Application.objects.filter(client_id=settings.OAUTH_CLIENT_ID,
                                           client_secret=settings.OAUTH_CLIENT_SECRET).count() == 1
 
-    @override_settings(DEBUG=True)	
-    @override_settings(OAUTH_CLIENT_ID='')	
-    @override_settings(OAUTH_CLIENT_SECRET='')	
-    def test_without_oauth_credentials(self):	
-        args = []	
-        opts = {}	
-        call_command('loadinitialdata', *args, **opts)	
+    @override_settings(DEBUG=True)
+    @override_settings(OAUTH_CLIENT_ID='')
+    @override_settings(OAUTH_CLIENT_SECRET='')
+    def test_without_oauth_credentials(self):
+        args = []
+        opts = {}
+        call_command('loadinitialdata', *args, **opts)
 
-        assert CoreGroup.objects.filter(name='Global Admin', is_global=True, permissions=15).count() == 1	
-        assert Organization.objects.filter(name=settings.DEFAULT_ORG).count() == 1	
-        assert Application.objects.all().count() == 0	
+        assert CoreGroup.objects.filter(name='Global Admin', is_global=True, permissions=15).count() == 1
+        assert Organization.objects.filter(name=settings.DEFAULT_ORG).count() == 1
+        assert Application.objects.all().count() == 0
         assert CoreUser.objects.filter(is_superuser=True).count() == 1
 
     @override_settings(DEBUG=True)
-    @override_settings(OAUTH_CLIENT_ID='123')	
+    @override_settings(OAUTH_CLIENT_ID='123')
     @override_settings(OAUTH_CLIENT_SECRET='456')
     def test_create_user_debug_no_password(self):
         args = []
@@ -81,7 +81,7 @@ class LoadInitialDataTest(TransactionTestCase):
         assert CoreGroup.objects.filter(name='Global Admin', is_global=True, permissions=15).count() == 1
         assert Organization.objects.filter(name=settings.DEFAULT_ORG).count() == 1
         assert CoreUser.objects.filter(is_superuser=True).count() == 1
-        assert Application.objects.filter(client_id=settings.OAUTH_CLIENT_ID,	
+        assert Application.objects.filter(client_id=settings.OAUTH_CLIENT_ID,
                                           client_secret=settings.OAUTH_CLIENT_SECRET).count() == 1
 
     @override_settings(DEBUG=False)

--- a/buildly/tests/test_loadinitialdata.py
+++ b/buildly/tests/test_loadinitialdata.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.test import TransactionTestCase, override_settings
 
+from oauth2_provider.models import Application
 from core.models import CoreGroup, CoreUser, Organization
 
 
@@ -28,6 +29,8 @@ class LoadInitialDataTest(TransactionTestCase):
         logging.disable(logging.NOTSET)
 
     @override_settings(DEBUG=True)
+    @override_settings(OAUTH_CLIENT_ID='123')	
+    @override_settings(OAUTH_CLIENT_SECRET='456')
     def test_full_initial_data(self):
         args = []
         opts = {}
@@ -36,9 +39,13 @@ class LoadInitialDataTest(TransactionTestCase):
         assert CoreGroup.objects.filter(name='Global Admin', is_global=True, permissions=15).count() == 1
         assert Organization.objects.filter(name=settings.DEFAULT_ORG).count() == 1
         assert CoreUser.objects.filter(is_superuser=True).count() == 1
+        assert Application.objects.filter(client_id=settings.OAUTH_CLIENT_ID,	
+                                          client_secret=settings.OAUTH_CLIENT_SECRET).count() == 1
 
     @override_settings(DEBUG=True)
     @override_settings(DEFAULT_ORG='')
+    @override_settings(OAUTH_CLIENT_ID='123')	
+    @override_settings(OAUTH_CLIENT_SECRET='456')
     def test_without_default_organization(self):
         args = []
         opts = {}
@@ -47,9 +54,25 @@ class LoadInitialDataTest(TransactionTestCase):
         assert CoreGroup.objects.filter(name='Global Admin', is_global=True, permissions=15).count() == 1
         assert Organization.objects.all().count() == 0
         assert CoreUser.objects.filter(is_superuser=True).count() == 1
+        assert Application.objects.filter(client_id=settings.OAUTH_CLIENT_ID,	
+                                          client_secret=settings.OAUTH_CLIENT_SECRET).count() == 1
 
+    @override_settings(DEBUG=True)	
+    @override_settings(OAUTH_CLIENT_ID='')	
+    @override_settings(OAUTH_CLIENT_SECRET='')	
+    def test_without_oauth_credentials(self):	
+        args = []	
+        opts = {}	
+        call_command('loadinitialdata', *args, **opts)	
+
+        assert CoreGroup.objects.filter(name='Global Admin', is_global=True, permissions=15).count() == 1	
+        assert Organization.objects.filter(name=settings.DEFAULT_ORG).count() == 1	
+        assert Application.objects.all().count() == 0	
+        assert CoreUser.objects.filter(is_superuser=True).count() == 1
 
     @override_settings(DEBUG=True)
+    @override_settings(OAUTH_CLIENT_ID='123')	
+    @override_settings(OAUTH_CLIENT_SECRET='456')
     def test_create_user_debug_no_password(self):
         args = []
         opts = {}
@@ -58,6 +81,8 @@ class LoadInitialDataTest(TransactionTestCase):
         assert CoreGroup.objects.filter(name='Global Admin', is_global=True, permissions=15).count() == 1
         assert Organization.objects.filter(name=settings.DEFAULT_ORG).count() == 1
         assert CoreUser.objects.filter(is_superuser=True).count() == 1
+        assert Application.objects.filter(client_id=settings.OAUTH_CLIENT_ID,	
+                                          client_secret=settings.OAUTH_CLIENT_SECRET).count() == 1
 
     @override_settings(DEBUG=False)
     def test_create_user_no_debug_no_password(self):

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -114,7 +114,7 @@ class CoreUserWritableSerializer(CoreUserSerializer):
 
     class Meta:
         model = CoreUser
-        fields = CoreUserSerializer.Meta.fields + ('password','organization_name')
+        fields = CoreUserSerializer.Meta.fields + ('password', 'organization_name')
         read_only_fields = CoreUserSerializer.Meta.read_only_fields
 
     def create(self, validated_data):

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -109,11 +109,12 @@ class CoreUserWritableSerializer(CoreUserSerializer):
     Override default CoreUser serializer for writable actions (create, update, partial_update)
     """
     password = serializers.CharField(write_only=True)
+    organization_name = serializers.CharField(source='organization.name')
     core_groups = serializers.PrimaryKeyRelatedField(many=True, queryset=CoreGroup.objects.all(), required=False)
 
     class Meta:
         model = CoreUser
-        fields = CoreUserSerializer.Meta.fields + ('password',)
+        fields = CoreUserSerializer.Meta.fields + ('password','organization_name')
         read_only_fields = CoreUserSerializer.Meta.read_only_fields
 
     def create(self, validated_data):
@@ -122,7 +123,7 @@ class CoreUserWritableSerializer(CoreUserSerializer):
             organization = validated_data.pop('organization')
         except (KeyError):
             organization = settings.DEFAULT_ORG
-        organization, is_new_org = Organization.objects.get_or_create(name=organization)
+        organization, is_new_org = Organization.objects.get_or_create(name=organization['name'])
 
         core_groups = validated_data.pop('core_groups', [])
 

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -122,8 +122,8 @@ class CoreUserWritableSerializer(CoreUserSerializer):
         try:
             organization = validated_data.pop('organization')
         except (KeyError):
-            organization = settings.DEFAULT_ORG
-        organization, is_new_org = Organization.objects.get_or_create(name=organization['name'])
+            organization = {'name': settings.DEFAULT_ORG}
+        organization, is_new_org = Organization.objects.get_or_create(**organization)
 
         core_groups = validated_data.pop('core_groups', [])
 

--- a/core/tests/fixtures.py
+++ b/core/tests/fixtures.py
@@ -16,7 +16,8 @@ TEST_USER_DATA = {
     'username': 'johnsnow',
     'password': '123qwe',
     'organization_uuid': uuid.uuid4(),
-    'organization': settings.DEFAULT_ORG,
+    # 'organization': settings.DEFAULT_ORG, # Tweaked this to support organization name from front end
+    'organization_name': settings.DEFAULT_ORG
 }
 
 
@@ -28,6 +29,7 @@ def superuser():
 @pytest.fixture
 def org():
     return factories.Organization(
+        name=TEST_USER_DATA['organization_name'],
         organization_uuid=TEST_USER_DATA['organization_uuid'],
     )
 

--- a/core/tests/test_coreuserview.py
+++ b/core/tests/test_coreuserview.py
@@ -96,13 +96,62 @@ def test_coreuser_views_permissions_org_member(request_factory, org_member):
 class TestCoreUserCreate:
 
     def test_registration_fail(self, request_factory):
-        # check that 'password' fields are required
-        for field_name in ['password']:
+        # check that 'password' and 'organization name' fields are required
+        for field_name in ['password', 'organization_name']:
             data = TEST_USER_DATA.copy()
             data.pop(field_name)
             request = request_factory.post(reverse('coreuser-list'), data)
             response = CoreUserViewSet.as_view({'post': 'create'})(request)
             assert response.status_code == 400
+
+    def test_registration_of_first_org_user(self, request_factory):	
+        request = request_factory.post(reverse('coreuser-list'), TEST_USER_DATA)	
+        response = CoreUserViewSet.as_view({'post': 'create'})(request)	
+        assert response.status_code == 201	
+
+        user = CoreUser.objects.get(username=TEST_USER_DATA['username'])	
+        assert user.email == TEST_USER_DATA['email']	
+        assert user.first_name == TEST_USER_DATA['first_name']	
+        assert user.last_name == TEST_USER_DATA['last_name']	
+        assert user.organization.name == TEST_USER_DATA['organization_name']	
+        assert user.is_active	
+
+        # check this user is org admin	
+        assert user.is_org_admin	
+
+    def test_registration_of_second_org_user(self, request_factory, org_admin):	
+        request = request_factory.post(reverse('coreuser-list'), TEST_USER_DATA)	
+        response = CoreUserViewSet.as_view({'post': 'create'})(request)	
+        assert response.status_code == 201	
+
+        user = CoreUser.objects.get(username=TEST_USER_DATA['username'])	
+        assert user.email == TEST_USER_DATA['email']	
+        assert user.first_name == TEST_USER_DATA['first_name']	
+        assert user.last_name == TEST_USER_DATA['last_name']	
+        assert user.organization.name == TEST_USER_DATA['organization_name']	
+        assert not user.is_active	
+
+        # check this user is NOT org admin	
+        assert not user.is_org_admin	
+
+    def test_registration_of_invited_org_user(self, request_factory, org_admin):	
+        data = TEST_USER_DATA.copy()	
+        token = create_invitation_token(data['email'], org_admin.organization)	
+        data['invitation_token'] = token	
+
+        request = request_factory.post(reverse('coreuser-list'), data)	
+        response = CoreUserViewSet.as_view({'post': 'create'})(request)	
+        assert response.status_code == 201	
+
+        user = CoreUser.objects.get(username=TEST_USER_DATA['username'])	
+        assert user.email == TEST_USER_DATA['email']	
+        assert user.first_name == TEST_USER_DATA['first_name']	
+        assert user.last_name == TEST_USER_DATA['last_name']	
+        assert user.organization.name == TEST_USER_DATA['organization_name']	
+        assert user.is_active	
+
+        # check this user is NOT org admin	
+        assert not user.is_org_admin
 
     def test_reused_token_invalidation(self, request_factory, org_admin):
         data = TEST_USER_DATA.copy()
@@ -127,7 +176,6 @@ class TestCoreUserCreate:
         data = TEST_USER_DATA.copy()
         groups = factories.CoreGroup.create_batch(2, organization=org_admin.organization)
         data['core_groups'] = [item.pk for item in groups]
-
         request = request_factory.post(reverse('coreuser-list'), data)
         response = CoreUserViewSet.as_view({'post': 'create'})(request)
         assert response.status_code == 201
@@ -218,7 +266,7 @@ class TestResetPassword(object):
     def test_reset_password_using_default_emailtemplate(self, request_factory, org_member):
         email = org_member.email
         assert list(org_member.organization.emailtemplate_set.all()) == []
-        assert list(Organization.objects.filter(name=settings.DEFAULT_ORG)) == []
+        # assert list(Organization.objects.filter(name=settings.DEFAULT_ORG)) == [] -- Removed this assertion to support organization name here
         request = request_factory.post(reverse('coreuser-reset-password'), {'email': email})
         response = CoreUserViewSet.as_view({'post': 'reset_password'})(request)
         assert response.status_code == 200

--- a/core/tests/test_coreuserview.py
+++ b/core/tests/test_coreuserview.py
@@ -11,7 +11,7 @@ from django.utils.http import urlsafe_base64_encode
 from rest_framework.reverse import reverse
 
 import factories
-from core.models import CoreUser, EmailTemplate, Organization, TEMPLATE_RESET_PASSWORD
+from core.models import CoreUser, EmailTemplate, TEMPLATE_RESET_PASSWORD
 from core.views import CoreUserViewSet
 from core.jwt_utils import create_invitation_token
 from core.tests.fixtures import org, org_admin, org_member, reset_password_request, TEST_USER_DATA
@@ -104,53 +104,53 @@ class TestCoreUserCreate:
             response = CoreUserViewSet.as_view({'post': 'create'})(request)
             assert response.status_code == 400
 
-    def test_registration_of_first_org_user(self, request_factory):	
-        request = request_factory.post(reverse('coreuser-list'), TEST_USER_DATA)	
-        response = CoreUserViewSet.as_view({'post': 'create'})(request)	
-        assert response.status_code == 201	
+    def test_registration_of_first_org_user(self, request_factory):
+        request = request_factory.post(reverse('coreuser-list'), TEST_USER_DATA)
+        response = CoreUserViewSet.as_view({'post': 'create'})(request)
+        assert response.status_code == 201
 
-        user = CoreUser.objects.get(username=TEST_USER_DATA['username'])	
-        assert user.email == TEST_USER_DATA['email']	
-        assert user.first_name == TEST_USER_DATA['first_name']	
-        assert user.last_name == TEST_USER_DATA['last_name']	
-        assert user.organization.name == TEST_USER_DATA['organization_name']	
-        assert user.is_active	
+        user = CoreUser.objects.get(username=TEST_USER_DATA['username'])
+        assert user.email == TEST_USER_DATA['email']
+        assert user.first_name == TEST_USER_DATA['first_name']
+        assert user.last_name == TEST_USER_DATA['last_name']
+        assert user.organization.name == TEST_USER_DATA['organization_name']
+        assert user.is_active
 
-        # check this user is org admin	
-        assert user.is_org_admin	
+        # check this user is org admin
+        assert user.is_org_admin
 
-    def test_registration_of_second_org_user(self, request_factory, org_admin):	
-        request = request_factory.post(reverse('coreuser-list'), TEST_USER_DATA)	
-        response = CoreUserViewSet.as_view({'post': 'create'})(request)	
-        assert response.status_code == 201	
+    def test_registration_of_second_org_user(self, request_factory, org_admin):
+        request = request_factory.post(reverse('coreuser-list'), TEST_USER_DATA)
+        response = CoreUserViewSet.as_view({'post': 'create'})(request)
+        assert response.status_code == 201
 
-        user = CoreUser.objects.get(username=TEST_USER_DATA['username'])	
-        assert user.email == TEST_USER_DATA['email']	
-        assert user.first_name == TEST_USER_DATA['first_name']	
-        assert user.last_name == TEST_USER_DATA['last_name']	
-        assert user.organization.name == TEST_USER_DATA['organization_name']	
-        assert not user.is_active	
+        user = CoreUser.objects.get(username=TEST_USER_DATA['username'])
+        assert user.email == TEST_USER_DATA['email']
+        assert user.first_name == TEST_USER_DATA['first_name']
+        assert user.last_name == TEST_USER_DATA['last_name']
+        assert user.organization.name == TEST_USER_DATA['organization_name']
+        assert not user.is_active
 
-        # check this user is NOT org admin	
-        assert not user.is_org_admin	
+        # check this user is NOT org admin
+        assert not user.is_org_admin
 
-    def test_registration_of_invited_org_user(self, request_factory, org_admin):	
-        data = TEST_USER_DATA.copy()	
-        token = create_invitation_token(data['email'], org_admin.organization)	
-        data['invitation_token'] = token	
+    def test_registration_of_invited_org_user(self, request_factory, org_admin):
+        data = TEST_USER_DATA.copy()
+        token = create_invitation_token(data['email'], org_admin.organization)
+        data['invitation_token'] = token
 
-        request = request_factory.post(reverse('coreuser-list'), data)	
-        response = CoreUserViewSet.as_view({'post': 'create'})(request)	
-        assert response.status_code == 201	
+        request = request_factory.post(reverse('coreuser-list'), data)
+        response = CoreUserViewSet.as_view({'post': 'create'})(request)
+        assert response.status_code == 201
 
-        user = CoreUser.objects.get(username=TEST_USER_DATA['username'])	
-        assert user.email == TEST_USER_DATA['email']	
-        assert user.first_name == TEST_USER_DATA['first_name']	
-        assert user.last_name == TEST_USER_DATA['last_name']	
-        assert user.organization.name == TEST_USER_DATA['organization_name']	
-        assert user.is_active	
+        user = CoreUser.objects.get(username=TEST_USER_DATA['username'])
+        assert user.email == TEST_USER_DATA['email']
+        assert user.first_name == TEST_USER_DATA['first_name']
+        assert user.last_name == TEST_USER_DATA['last_name']
+        assert user.organization.name == TEST_USER_DATA['organization_name']
+        assert user.is_active
 
-        # check this user is NOT org admin	
+        # check this user is NOT org admin
         assert not user.is_org_admin
 
     def test_reused_token_invalidation(self, request_factory, org_admin):

--- a/datamesh/services.py
+++ b/datamesh/services.py
@@ -98,7 +98,7 @@ class DataMesh:
                 if hasattr(self._access_validator, 'validate') and callable(self._access_validator.validate):
                     self._access_validator.validate(obj)
                 else:
-                    raise DatameshConfigurationError(f'DataMesh Error: Access Validator should have validate method')
+                    raise DatameshConfigurationError(f'{"DataMesh Error:Access Validator should have validate method"}')
             obj_dict = model_to_dict(obj)
             data_item[relationship.key].append(obj_dict)
             self._cache[cache_key] = obj_dict
@@ -133,7 +133,7 @@ class DataMesh:
                 else:
                     logger.error(f'No response data for join record (request params: {params})')
             else:
-                raise DatameshConfigurationError(f'DataMesh Error: Client should have request method')
+                raise DatameshConfigurationError(f'{"DataMesh Error: Client should have request method"}')
 
     async def async_extend_data(self, data: Union[dict, list], client_map: Dict[str, Any]):
         """

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,6 @@ django-cors-headers==2.5.3
 pyswagger==0.8.39
 bravado-core==5.13.1
 drf-yasg==1.10.2
-requests==2.21.0
+requests==2.25.0
 aiohttp==3.5.4
 django-auth-ldap==2.1.0
-urllib3==1.24.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,3 +14,4 @@ drf-yasg==1.10.2
 requests==2.21.0
 aiohttp==3.5.4
 django-auth-ldap==2.1.0
+urllib3==1.24.3


### PR DESCRIPTION
## Purpose
_Give organization name as a parameter to be accepted when creating core user_

## Approach
_Added organization name in serializer_
_Tweaked acceptance of organization name in serializer_

### Further Info
Ticket number: #25 
 
@glind 
