### PR TITLE
Revert "Fix issue for retrieve query by uuid"

### DIFF
--- a/gateway/clients.py
+++ b/gateway/clients.py
@@ -40,13 +40,7 @@ class BaseSwaggerClient:
         if kwargs.get('pk') is None:
             path = f'/{model}/'
         else:
-            # It was checking shipment/{uuid} in API specification when pk is of uuid type,
-            # as TP services are mainly using
-            # shipment/{id}
-            # Commenting code to make it work for id, as TP services don't have endpoint to 
-            # make request by uuid
-            # pk_name = 'uuid' if utils.valid_uuid4(pk) else 'id'
-            pk_name = 'id'
+            pk_name = 'uuid' if utils.valid_uuid4(pk) else 'id'
             path_kwargs = {pk_name: pk}
             path = f'/{model}/{{{pk_name}}}/'
 


### PR DESCRIPTION
Reverts TransparentPath/buildly-core#88
There will be refactoring for requests by UUID instead of pk. Here changes in this PR are not useful, therefore reverting the changes.