### PR TITLE
Automatically assign custodian organization for newly created custodian

### DIFF
--- a/core/serializers.py
+++ b/core/serializers.py
@@ -307,7 +307,7 @@ class CoreUserResetPasswordConfirmSerializer(CoreUserResetPasswordCheckSerialize
         return self.user
 
 
-class OrganizationSerializer(serializers.ModelSerializer):
+class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
     id = serializers.UUIDField(source='organization_uuid', read_only=True)
 
     class Meta:

--- a/core/views/organization.py
+++ b/core/views/organization.py
@@ -45,6 +45,7 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 
+    filter_fields = ('name',)
     filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
     permission_classes = (IsOrgMember,)
     queryset = Organization.objects.all()


### PR DESCRIPTION
## Purpose
Allow organizations to be searched by name.

## Approach

- converted ModelSerializer to HyperlinkedModelSerializer for OrganizationSerializer
- added name filter field for OrganizationViewSet

### Further Info
Ticket number: [#45](https://github.com/TransparentPath/custodian_service/issues/45)
 
@yasmin2496 
